### PR TITLE
add python for use on nodejs10+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,42 +7,72 @@ RUN yum update -y && yum install -y unzip make wget
 ADD https://s3.amazonaws.com/aws-cli/awscli-bundle.zip /root
 
     
-RUN unzip awscli-bundle.zip && \
-    cd awscli-bundle;
+RUN unzip awscli-bundle.zip
     
 #RUN ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
 RUN ./awscli-bundle/install -i /opt/awscli -b /opt/awscli/aws
-  
+
 # install jq
 RUN wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 \
 && mv jq-linux64 /opt/awscli/jq \
 && chmod +x /opt/awscli/jq
-  
+
+# resolve symlinks
+RUN cp -RL /opt/awscli /opt/awscli-resolved
+
 #
 # prepare the runtime at /opt/awscli
 #
-  
-FROM lambci/lambda:provided as runtime
+
+FROM lambci/lambda:provided as prepareCli
 
 USER root
 
-RUN yum install -y zip 
-
-COPY --from=builder /opt/awscli/lib/python2.7/site-packages/ /opt/awscli/ 
-COPY --from=builder /opt/awscli/bin/ /opt/awscli/bin/ 
-COPY --from=builder /opt/awscli/bin/aws /opt/awscli/aws
-COPY --from=builder /opt/awscli/jq /opt/awscli/jq
+COPY --from=builder /opt/awscli-resolved/lib/python2.7/site-packages/ /opt/awscli/
+COPY --from=builder /opt/awscli-resolved/bin/ /opt/awscli/bin/
+COPY --from=builder /opt/awscli-resolved/jq /opt/awscli/jq
 COPY --from=builder /usr/bin/make /opt/awscli/make
+COPY --from=builder /usr/lib64/libpython2.7.so.1.0 /opt/awscli/lib64/libpython2.7.so.1.0
+COPY --from=builder /usr/lib64/libexpat.so.1 /opt/awscli/lib64/libexpat.so.1
+COPY --from=builder /usr/lib64/python2.7/ /opt/awscli/lib64/python2.7
+
+# create a wrapper for the bin with the new lib path.
+RUN echo '#!/bin/bash' > /opt/awscli/aws \
+&& echo 'PYTHONPATH=/opt/awscli LD_LIBRARY_PATH=/opt/awscli/lib64/ /opt/awscli/bin/aws $@' >> /opt/awscli/aws \
+&& chmod +x /opt/awscli/aws
 
 # remove unnecessary files to reduce the size
 RUN rm -rf /opt/awscli/pip* /opt/awscli/setuptools* /opt/awscli/awscli/examples
 
-#&& mv /opt/awscli/site-packages/* /opt/awscli/
-
 # get the version number
 RUN grep "__version__" /opt/awscli/awscli/__init__.py | egrep -o "1.[0-9.]+" > /AWSCLI_VERSION
 
+#
+# ensure no missing linked libraries
+# NOTE that this is only checking the Python executable! It may need to be expanded upon later.
+#
+FROM lambci/lambda:nodejs12.x as testNodeJs12x
+
+USER root
+
+COPY --from=prepareCli /opt/awscli/ /opt/awscli/
+
+ENV LD_LIBRARY_PATH /opt/awscli/lib64/
+COPY lddtest ./lddtest
+COPY lddtest ./lddtest
+RUN ./lddtest /opt/awscli/bin/python
+
+#
 # zip up
+#
+FROM lambci/lambda:provided as runtime
+
+USER root
+
+COPY --from=prepareCli /opt/awscli/ /opt/awscli/
+COPY --from=prepareCli /AWSCLI_VERSION /AWSCLI_VERSION
+
+RUN yum install -y zip
 RUN cd /opt; zip -r ../layer.zip *; \
 echo "/layer.zip is ready"; \
 ls -alh /layer.zip;

--- a/lddtest
+++ b/lddtest
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+TARGET="$1"
+
+if ldd "${TARGET}" | grep -q 'not found';
+then
+  echo >&2 "${TARGET} is missing dependencies!"
+  ldd "${TARGET}" | grep 'not found' >&2
+  exit 1
+fi


### PR DESCRIPTION
*Issue #, if available:*
#5

*Description of changes:*
- add python required files to layer for nodejs10+ runtimes.
- add rudimentary "testNodeJs12x" docker stage which runs ldd on the python executable to check for missing deps

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
