### PR TITLE
Hotfix/use custom profile in sam cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ sam-layer-publish:
 	-v $(HOME)/.aws:/home/samcli/.aws \
 	-w /home/samcli/workdir \
 	-e AWS_DEFAULT_REGION=$(LAMBDA_REGION) \
-	pahud/aws-sam-cli:latest sam publish --region $(LAMBDA_REGION) --template sam-layer-packaged.yaml \
+	pahud/aws-sam-cli:latest sam publish --profile=$(AWS_PROFILE) --region $(LAMBDA_REGION) --template sam-layer-packaged.yaml \
 	--semantic-version $(shell cat AWSCLI_VERSION)
 	@echo "=> version $(shell cat AWSCLI_VERSION) published to $(LAMBDA_REGION)"
 

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ sam-layer-package:
 	-v $(HOME)/.aws:/home/samcli/.aws \
 	-w /home/samcli/workdir \
 	-e AWS_DEFAULT_REGION=$(LAMBDA_REGION) \
-	pahud/aws-sam-cli:latest sam package --template-file sam-layer.yaml --s3-bucket $(S3BUCKET) --output-template-file sam-layer-packaged.yaml
+	pahud/aws-sam-cli:latest sam package --profile=$(AWS_PROFILE) --template-file sam-layer.yaml --s3-bucket $(S3BUCKET) --output-template-file sam-layer-packaged.yaml
 	@echo "[OK] Now type 'make sam-layer-deploy' to deploy your Lambda layer with SAM"
 
 

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ sam-layer-deploy:
 	-v $(HOME)/.aws:/home/samcli/.aws \
 	-w /home/samcli/workdir \
 	-e AWS_DEFAULT_REGION=$(LAMBDA_REGION) \
-	pahud/aws-sam-cli:latest sam deploy --template-file ./sam-layer-packaged.yaml --stack-name "$(LAYER_NAME)-stack" \
+	pahud/aws-sam-cli:latest sam deploy --profile=$(AWS_PROFILE) --template-file ./sam-layer-packaged.yaml --stack-name "$(LAYER_NAME)-stack" \
 	--parameter-overrides LayerName=$(LAYER_NAME) \
 	--capabilities CAPABILITY_IAM
 	# print the cloudformation stack outputs


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When deploying a scratch build using a profile other than the default, the profile was not used.
So I fixed to be able to set the profile when running sam cli with the following three commands.
- sam-layer-package
- sam-layer-publish
- sam-layer-deploy

### steps to reproduce

#### 1. Empty the default profile and add another profile

```
# ~/.aws/credentials
[default]
aws_access_key_id=
aws_secret_access_key=

[another]
aws_access_key_id=******
aws_secret_access_key=******
```

#### 2. Run sam-layer-package

- before fixed

```bash
AWS_PROFILE=another S3BUCKET=sample-sam-tmp LAMBDA_REGION=ap-northeast-1 make sam-layer-package

Error: Unable to upload artifact README.md referenced by ReadmeUrl parameter of AWS::ServerlessRepo::Application resource.
An error occurred (AuthorizationHeaderMalformed) when calling the PutObject operation: The authorization header is malformed; a non-empty Access Key (AKID) must be provided in the credential.
make: *** [sam-layer-package] Error 1
```

- after fixed

```bash
AWS_PROFILE=another S3BUCKET=sample-sam-tmp LAMBDA_REGION=ap-northeast-1 make sam-layer-package

[OK] Now type 'make sam-layer-deploy' to deploy your Lambda layer with SAM
```

#### 3. Run sam-layer-deploy

- before fixed

```bash
AWS_PROFILE=another S3BUCKET=sample-sam-tmp LAMBDA_REGION=ap-northeast-1 make sam-layer-deploy

Initiating deployment
=====================
Error: Failed to create changeset for the stack: awscli-layer-stack, An error occurred (InvalidClientTokenId) when calling the CreateChangeSet operation: The security token included in the request is invalid.
make: *** [sam-layer-deploy] Error 1
```

- after fixed

```bash
AWS_PROFILE=another S3BUCKET=sample-sam-tmp LAMBDA_REGION=ap-northeast-1 make sam-layer-deploy

[OK] Layer version deployed.
```

#### 4. Run sam-layer-publish

- before fixed

```bash
AWS_PROFILE=another S3BUCKET=sample-sam-tmp LAMBDA_REGION=ap-northeast-1 make sam-layer-publish

Publish Failed
Error: The security token included in the request is invalid.
Please follow the instructions in https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-template-publishing-applications.html
make: *** [sam-layer-publish] Error 1
```

- after fixed

```bash
AWS_PROFILE=another S3BUCKET=sample-sam-tmp LAMBDA_REGION=ap-northeast-1 make sam-layer-publish

=> version 1.18.150 published to ap-northeast-1
```