### PR TITLE
Remove trailing semicolons from Dockerfile

### DIFF
--- a/Dockerfile.python27
+++ b/Dockerfile.python27
@@ -30,9 +30,9 @@ RUN yum install -y zip
 
 COPY --from=builder /opt/awscli/lib/python2.7/site-packages/ /opt/awscli/ 
 COPY --from=builder /opt/awscli/bin/ /opt/awscli/bin/ 
-COPY --from=builder /opt/awscli/bin/aws /opt/awscli/aws; 
-COPY --from=builder /opt/awscli/jq /opt/awscli/jq; 
-COPY --from=builder /usr/bin/make /opt/awscli/make; 
+COPY --from=builder /opt/awscli/bin/aws /opt/awscli/aws
+COPY --from=builder /opt/awscli/jq /opt/awscli/jq
+COPY --from=builder /usr/bin/make /opt/awscli/make
 
 # copy shared lib
 COPY --from=builder /usr/lib64/libpython2.7.so.1.0 /opt/awscli/lib/


### PR DESCRIPTION
Not sure if these semicolons were intentional (please close PR if so)

### Fixed
- Removed trailing semicolon from Dockerfile
